### PR TITLE
Add support for .internal TLD

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -154,7 +154,9 @@ function checkOrigin(str) {
 		throw new Error("origin was malformatted");
 	}
 	
-	var isLocalhost = (originUrl.hostname == "localhost" || originUrl.hostname.endsWith(".localhost"));
+	var isLocalhost = (originUrl.hostname == "localhost" ||
+			   originUrl.hostname.endsWith(".localhost") ||
+			   originUrl.hostname.endsWith(".internal"));
 
 	if (originUrl.protocol !== "https:" && !isLocalhost) {
 		throw new Error("origin should be https");


### PR DESCRIPTION
.internal is a proposed[0] reserved TLD and is already widely-recognized as serving such function.

[0] https://tools.ietf.org/html/draft-wkumari-dnsop-internal-00