### PR TITLE
feat: authenticators that do not support counters

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -545,13 +545,16 @@ async function validateUserHandle() {
 async function validateCounter() {
 	var prevCounter = this.expectations.get("prevCounter");
 	var counter = this.authnrData.get("counter");
+	var counterSupported = !(counter === 0 && prevCounter === 0);
 
-	if (counter <= prevCounter) {
+	if (counter <= prevCounter && counterSupported) {
 		throw new Error("counter rollback detected");
 	}
 
-	this.audit.journal.add("counter");
-
+	if(counterSupported) {
+		this.audit.journal.add("counter");
+	}
+	
 	return true;
 }
 

--- a/test/validatorTest.js
+++ b/test/validatorTest.js
@@ -711,6 +711,14 @@ describe("assertion validation", function() {
 			assert.isTrue(assnResp.audit.journal.has("counter"));
 		});
 
+		it("returns true if counter is not supported but do not add it to journal", async function () {
+			assnResp.authnrData.set("counter", 0);
+			assnResp.expectations.set("prevCounter", 0);
+			var ret = await assnResp.validateCounter();
+			assert.isTrue(ret);
+			assert.isFalse(assnResp.audit.journal.has("counter"));
+		});
+
 		it("throws if counter is the same", function() {
 			assert.strictEqual(assnResp.authnrData.get("counter"), 363);
 			assnResp.expectations.set("prevCounter", 363);


### PR DESCRIPTION
Some authenticators (e. g. TouchID and FaceID in WebKit) do not support counters (https://webkit.org/blog/11312/meet-face-id-and-touch-id-for-the-web/). If bot previous and current counter value are zero, a counter is not supported. It should pass validation but the audit should reflect that.