### PR TITLE
Fix assertions failing when counter is not supported.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -15,8 +15,8 @@ const lockSym = Symbol();
  * @property {Boolean} audit.validRequest Whether the request message was complete and valid
  * @property {Boolean} audit.complete Whether all fields in the result have been validated
  * @property {Set} audit.journal A list of the fields that were validated
- * @property {Map} audit.warning A set of warnigns that were generated while validating the result
- * @property {Map} audit.info A set of informational fields that were generated while validating the result. Includes any x509 extensions of the attestation certificate during registration.
+ * @property {Map} audit.warning A set of warnings that were generated while validating the result
+ * @property {Map} audit.info A set of informational fields that were generated while validating the result. Includes any x509 extensions of the attestation certificate during registration, and whether the key supports a rollback counter during authentication.
  */
 class Fido2Result {
 	constructor(sym) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -551,9 +551,8 @@ async function validateCounter() {
 		throw new Error("counter rollback detected");
 	}
 
-	if(counterSupported) {
-		this.audit.journal.add("counter");
-	}
+	this.audit.journal.add("counter");
+	this.audit.info.set("counter-supported", "" + counterSupported);
 	
 	return true;
 }

--- a/test/mainTest.js
+++ b/test/mainTest.js
@@ -640,8 +640,8 @@ describe("Fido2Lib", function() {
 				response: {
 					authenticatorData: coerceToArrayBuffer("YS67HU8UTNyqQ5f-EVzitWw5paVnpyhQli2ahN6PS6UFAAAAAA", "authenticatorData"), 
 					clientDataJSON: coerceToArrayBuffer("eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiZ19QdTMyYnBsdWt0eHVnTk5CTFgtWk81Tjl1YjBENTBiSkVSYktpVTJHV09OM21kMHJSOUNhUVlkUEhkQ2dvLWRwaTEtOWdiSkp2bUN1SERuaDA0UmciLCJvcmlnaW4iOiJodHRwczovL21pZ2h0eS1maXJlYW50LTg0LmxvY2EubHQifQ", "clientDataJSON"),
-					signature: coerceToArrayBuffer("MEQCIEhIhQBglBn1iGMDgF4WFDG7ISJHD1C1Q60drTaijjV2AiBOnQleadMnzcMJ0EBpwoP8zr2V5lBuKvpNfJrcbC1T4w", "signature")
-				}
+					signature: coerceToArrayBuffer("MEQCIEhIhQBglBn1iGMDgF4WFDG7ISJHD1C1Q60drTaijjV2AiBOnQleadMnzcMJ0EBpwoP8zr2V5lBuKvpNfJrcbC1T4w", "signature"),
+				},
 			};
 
 			return serv.assertionResult(assertionResponse, expectations).then((res) => {

--- a/test/mainTest.js
+++ b/test/mainTest.js
@@ -621,6 +621,34 @@ describe("Fido2Lib", function() {
 				return res;
 			});
 		});
+
+		it("valid assertion without counter supported", function() {
+			var expectations = {
+				challenge: "g_Pu32bpluktxugNNBLX-ZO5N9ub0D50bJERbKiU2GWON3md0rR9CaQYdPHdCgo-dpi1-9gbJJvmCuHDnh04Rg",
+				origin: "https://mighty-fireant-84.loca.lt",
+				factor: "first",
+				publicKey: "-----BEGIN PUBLIC KEY-----\n" +
+				"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0dBhdNNvh2NkaNstlFhrBhi9yrjP\n" +
+				"0qPqZvRRnf3zQiN9zDwJ9ZXoyO4dhKz3OIhMBJG6F+muH35fEsWBZI6dhg==\n" +
+				"-----END PUBLIC KEY-----\n",
+				prevCounter: 0,
+				userHandle: null,
+			};
+
+			var assertionResponse = {
+				rawId: coerceToArrayBuffer("7S8aQSSxqPkztahKbgw36Mr_-hE", "rawId"),
+				response: {
+					authenticatorData: coerceToArrayBuffer("YS67HU8UTNyqQ5f-EVzitWw5paVnpyhQli2ahN6PS6UFAAAAAA", "authenticatorData"), 
+					clientDataJSON: coerceToArrayBuffer("eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiZ19QdTMyYnBsdWt0eHVnTk5CTFgtWk81Tjl1YjBENTBiSkVSYktpVTJHV09OM21kMHJSOUNhUVlkUEhkQ2dvLWRwaTEtOWdiSkp2bUN1SERuaDA0UmciLCJvcmlnaW4iOiJodHRwczovL21pZ2h0eS1maXJlYW50LTg0LmxvY2EubHQifQ", "clientDataJSON"),
+					signature: coerceToArrayBuffer("MEQCIEhIhQBglBn1iGMDgF4WFDG7ISJHD1C1Q60drTaijjV2AiBOnQleadMnzcMJ0EBpwoP8zr2V5lBuKvpNfJrcbC1T4w", "signature")
+				}
+			};
+
+			return serv.assertionResult(assertionResponse, expectations).then((res) => {
+				assert.instanceOf(res, Fido2AssertionResult);
+				return res;
+			});
+		});
 	});
 
 	describe("addAttestationFormat", function() {

--- a/test/validatorTest.js
+++ b/test/validatorTest.js
@@ -709,6 +709,7 @@ describe("assertion validation", function() {
 			var ret = await assnResp.validateCounter();
 			assert.isTrue(ret);
 			assert.isTrue(assnResp.audit.journal.has("counter"));
+			assert.equal(assnResp.audit.info.get("counter-supported"), "true");
 		});
 
 		it("returns true if counter is not supported but do not add it to journal", async function () {
@@ -716,7 +717,8 @@ describe("assertion validation", function() {
 			assnResp.expectations.set("prevCounter", 0);
 			var ret = await assnResp.validateCounter();
 			assert.isTrue(ret);
-			assert.isFalse(assnResp.audit.journal.has("counter"));
+			assert.isTrue(assnResp.audit.journal.has("counter"));
+			assert.equal(assnResp.audit.info.get("counter-supported"), "false");
 		});
 
 		it("throws if counter is the same", function() {


### PR DESCRIPTION
When `counterSupported` is false, the journal validation fails because `counter` isn't added to the journal. This fixes those assertions by always adding `counter` to the list. In the resulting audit, the value of `counterSupported` is added to the info map instead so those authenticators can be detected.

This could be considered a breaking change since the original PR that added support for authenticators without counters (#8) indicated an authenticator without a counter by not adding `counter` to the journal. However, authenticators without a counter would not be able to pass validation here, so this behavior would not be visible. (I've added a test for this behavior to `mainTest.js` that just makes sure those authentications are supported; it fails without these changes.)

See https://github.com/FIDO-Tools/fido2-library/issues/7#issuecomment-841479714.