### PR TITLE
security-fix: upgrade gh-pages to ^3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"eslint": "^6.8.0",
 				"eslint-plugin-vue": "^6.2.2",
 				"fido2-helpers": "^1.7.2",
-				"gh-pages": "^2.2.0",
+				"gh-pages": "^3.2.1",
 				"jsdoc": "^3.5.5",
 				"mocha": "^6.1.4",
 				"mockery": "^2.0.0",
@@ -1365,39 +1365,45 @@
 			}
 		},
 		"node_modules/filename-reserved-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-			"integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
 			"dev": true,
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=4"
 			}
 		},
 		"node_modules/filenamify": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
-			"integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+			"integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
 			"dev": true,
 			"dependencies": {
-				"filename-reserved-regex": "^1.0.0",
-				"strip-outer": "^1.0.0",
+				"filename-reserved-regex": "^2.0.0",
+				"strip-outer": "^1.0.1",
 				"trim-repeated": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/filenamify-url": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
-			"integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-2.1.2.tgz",
+			"integrity": "sha512-3rMbAr7vDNMOGsj1aMniQFl749QjgM+lMJ/77ZRSPTIgxvolZwoQbn8dXLs7xfd+hAdli+oTnSWZNkJJLWQFEQ==",
 			"dev": true,
 			"dependencies": {
-				"filenamify": "^1.0.0",
-				"humanize-url": "^1.0.0"
+				"filenamify": "^4.3.0",
+				"humanize-url": "^2.1.1"
 			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/find-cache-dir": {
@@ -1543,15 +1549,16 @@
 			}
 		},
 		"node_modules/gh-pages": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-2.2.0.tgz",
-			"integrity": "sha512-c+yPkNOPMFGNisYg9r4qvsMIjVYikJv7ImFOhPIVPt0+AcRUamZ7zkGRLHz7FKB0xrlZ+ddSOJsZv9XAFVXLmA==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.2.1.tgz",
+			"integrity": "sha512-/JLALwM9vTSohmaO9RZSWS+oCcVkV4pMyUwdQPZuxeJN5mVwz2kRbT6RigqDoqM8Rber2sv+WIMLP/9ZPfc7oA==",
 			"dev": true,
 			"dependencies": {
 				"async": "^2.6.1",
 				"commander": "^2.18.0",
 				"email-addresses": "^3.0.1",
-				"filenamify-url": "^1.0.0",
+				"filenamify-url": "^2.1.1",
+				"find-cache-dir": "^3.3.1",
 				"fs-extra": "^8.1.0",
 				"globby": "^6.1.0"
 			},
@@ -1560,7 +1567,7 @@
 				"gh-pages-clean": "bin/gh-pages-clean.js"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=10"
 			}
 		},
 		"node_modules/gh-pages/node_modules/commander": {
@@ -1568,6 +1575,96 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
+		},
+		"node_modules/gh-pages/node_modules/find-cache-dir": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+			"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+			"dev": true,
+			"dependencies": {
+				"commondir": "^1.0.1",
+				"make-dir": "^3.0.2",
+				"pkg-dir": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+			}
+		},
+		"node_modules/gh-pages/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/gh-pages/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/gh-pages/node_modules/make-dir": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/gh-pages/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/gh-pages/node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/gh-pages/node_modules/pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/glob": {
 			"version": "7.1.7",
@@ -1763,16 +1860,15 @@
 			}
 		},
 		"node_modules/humanize-url": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
-			"integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-2.1.1.tgz",
+			"integrity": "sha512-V4nxsPGNE7mPjr1qDp471YfW8nhBiTRWrG/4usZlpvFU8I7gsV7Jvrrzv/snbLm5dWO3dr1ennu2YqnhTWFmYA==",
 			"dev": true,
 			"dependencies": {
-				"normalize-url": "^1.0.0",
-				"strip-url-auth": "^1.0.0"
+				"normalize-url": "^4.5.1"
 			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -2120,15 +2216,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-regex": {
@@ -2963,18 +3050,12 @@
 			}
 		},
 		"node_modules/normalize-url": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
 			"dev": true,
-			"dependencies": {
-				"object-assign": "^4.0.1",
-				"prepend-http": "^1.0.0",
-				"query-string": "^4.1.0",
-				"sort-keys": "^1.0.0"
-			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
 			}
 		},
 		"node_modules/nyc": {
@@ -3351,15 +3432,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/prepend-http": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -3403,19 +3475,6 @@
 			"integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==",
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/query-string": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-			"dev": true,
-			"dependencies": {
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/read-pkg": {
@@ -3662,18 +3721,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/sort-keys": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-			"dev": true,
-			"dependencies": {
-				"is-plain-obj": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -3742,15 +3789,6 @@
 			"dev": true,
 			"dependencies": {
 				"stubs": "^3.0.0"
-			}
-		},
-		"node_modules/strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/string-width": {
@@ -3855,15 +3893,6 @@
 			"dependencies": {
 				"escape-string-regexp": "^1.0.2"
 			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/strip-url-auth": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
-			"integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5477,30 +5506,30 @@
 			}
 		},
 		"filename-reserved-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-			"integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
 			"dev": true
 		},
 		"filenamify": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
-			"integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+			"integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
 			"dev": true,
 			"requires": {
-				"filename-reserved-regex": "^1.0.0",
-				"strip-outer": "^1.0.0",
+				"filename-reserved-regex": "^2.0.0",
+				"strip-outer": "^1.0.1",
 				"trim-repeated": "^1.0.0"
 			}
 		},
 		"filenamify-url": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
-			"integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-2.1.2.tgz",
+			"integrity": "sha512-3rMbAr7vDNMOGsj1aMniQFl749QjgM+lMJ/77ZRSPTIgxvolZwoQbn8dXLs7xfd+hAdli+oTnSWZNkJJLWQFEQ==",
 			"dev": true,
 			"requires": {
-				"filenamify": "^1.0.0",
-				"humanize-url": "^1.0.0"
+				"filenamify": "^4.3.0",
+				"humanize-url": "^2.1.1"
 			}
 		},
 		"find-cache-dir": {
@@ -5624,15 +5653,16 @@
 			}
 		},
 		"gh-pages": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-2.2.0.tgz",
-			"integrity": "sha512-c+yPkNOPMFGNisYg9r4qvsMIjVYikJv7ImFOhPIVPt0+AcRUamZ7zkGRLHz7FKB0xrlZ+ddSOJsZv9XAFVXLmA==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.2.1.tgz",
+			"integrity": "sha512-/JLALwM9vTSohmaO9RZSWS+oCcVkV4pMyUwdQPZuxeJN5mVwz2kRbT6RigqDoqM8Rber2sv+WIMLP/9ZPfc7oA==",
 			"dev": true,
 			"requires": {
 				"async": "^2.6.1",
 				"commander": "^2.18.0",
 				"email-addresses": "^3.0.1",
-				"filenamify-url": "^1.0.0",
+				"filenamify-url": "^2.1.1",
+				"find-cache-dir": "^3.3.1",
 				"fs-extra": "^8.1.0",
 				"globby": "^6.1.0"
 			},
@@ -5642,6 +5672,69 @@
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 					"dev": true
+				},
+				"find-cache-dir": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+					"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^3.0.2",
+						"pkg-dir": "^4.1.0"
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"make-dir": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
 				}
 			}
 		},
@@ -5794,13 +5887,12 @@
 			}
 		},
 		"humanize-url": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
-			"integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-2.1.1.tgz",
+			"integrity": "sha512-V4nxsPGNE7mPjr1qDp471YfW8nhBiTRWrG/4usZlpvFU8I7gsV7Jvrrzv/snbLm5dWO3dr1ennu2YqnhTWFmYA==",
 			"dev": true,
 			"requires": {
-				"normalize-url": "^1.0.0",
-				"strip-url-auth": "^1.0.0"
+				"normalize-url": "^4.5.1"
 			}
 		},
 		"iconv-lite": {
@@ -6029,12 +6121,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
 			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
-			"dev": true
-		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
 			"dev": true
 		},
 		"is-regex": {
@@ -6733,16 +6819,10 @@
 			}
 		},
 		"normalize-url": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-			"dev": true,
-			"requires": {
-				"object-assign": "^4.0.1",
-				"prepend-http": "^1.0.0",
-				"query-string": "^4.1.0",
-				"sort-keys": "^1.0.0"
-			}
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+			"integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
+			"dev": true
 		},
 		"nyc": {
 			"version": "14.1.1",
@@ -7024,12 +7104,6 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
-		"prepend-http": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-			"dev": true
-		},
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -7062,16 +7136,6 @@
 			"version": "1.0.17",
 			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
 			"integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
-		},
-		"query-string": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-			"dev": true,
-			"requires": {
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
-			}
 		},
 		"read-pkg": {
 			"version": "3.0.0",
@@ -7257,15 +7321,6 @@
 				}
 			}
 		},
-		"sort-keys": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-			"dev": true,
-			"requires": {
-				"is-plain-obj": "^1.0.0"
-			}
-		},
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -7332,12 +7387,6 @@
 			"requires": {
 				"stubs": "^3.0.0"
 			}
-		},
-		"strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-			"dev": true
 		},
 		"string-width": {
 			"version": "4.2.2",
@@ -7416,12 +7465,6 @@
 			"requires": {
 				"escape-string-regexp": "^1.0.2"
 			}
-		},
-		"strip-url-auth": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
-			"integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
-			"dev": true
 		},
 		"stubs": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"eslint": "^6.8.0",
 		"eslint-plugin-vue": "^6.2.2",
 		"fido2-helpers": "^1.7.2",
-		"gh-pages": "^2.2.0",
+		"gh-pages": "^3.2.1",
 		"jsdoc": "^3.5.5",
 		"mocha": "^6.1.4",
 		"mockery": "^2.0.0",


### PR DESCRIPTION
Fixed npm audit report related to gh-pages, although it's a major version update doesn't seem to change anything on cli options

npm audit report:
```
# npm audit report

normalize-url  <=4.5.0 || 5.0.0 - 5.3.0 || 6.0.0
Severity: high
Regular Expression Denial of Service - https://npmjs.com/advisories/1755
fix available via `npm audit fix --force`
Will install gh-pages@3.2.1, which is a breaking change
node_modules/normalize-url
  humanize-url  <=1.0.1
  Depends on vulnerable versions of normalize-url
  node_modules/humanize-url
    filenamify-url  1.0.0
    Depends on vulnerable versions of humanize-url
    node_modules/filenamify-url
      gh-pages  1.2.0 - 3.2.0
      Depends on vulnerable versions of filenamify-url
      node_modules/gh-pages

4 high severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force
```